### PR TITLE
I broke the SH format with BASH syntax!

### DIFF
--- a/anp/Dockerfile
+++ b/anp/Dockerfile
@@ -1,11 +1,11 @@
 #From https://github.com/bgernert/docker-radsecproxy/blob/master/Dockerfile
 # Use official Alpine release
-FROM alpine:3.14.3 as build
+FROM alpine:3.22.0 as build
 
 # Maintainer
 LABEL maintainer="Björn Gernert <mail@bjoern-gernert.de>"
 
-ENV RADSECVERSION 1.9.1
+ENV RADSECVERSION 1.11.2
 ENV RADSECURL https://github.com/radsecproxy/radsecproxy/releases/download/${RADSECVERSION}/
 ENV RADSECFILENAME radsecproxy-${RADSECVERSION}.tar.gz
 
@@ -36,7 +36,7 @@ RUN make && make install
 # --- --- ---
 
 # Create Radsecproxy container
-FROM alpine:3.14.3
+FROM alpine:3.22.0
 
 # Update apk
 RUN apk update

--- a/anp/Dockerfile
+++ b/anp/Dockerfile
@@ -42,7 +42,7 @@ FROM alpine:3.14.3
 RUN apk update
 
 # Install openssl, ca-certificates, nettle and tini
-RUN apk add --no-cache openssl ca-certificates bash nettle tini bind-tools
+RUN apk add --no-cache openssl ca-certificates bash nettle tini bind-tools grep
 
 # Copy from 'build' stage
 COPY --from=build /root/output/ /

--- a/anp/configs/radsecproxy/naptr-openroaming.sh
+++ b/anp/configs/radsecproxy/naptr-openroaming.sh
@@ -17,6 +17,7 @@ test -n "${1}" || usage
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
+GREPCMD=$(command -v grep)
 
 validate_host() {
          echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
@@ -79,12 +80,12 @@ if [ -z "${ORIG_REALM}" ]; then
 fi
 
 # for 3gppnetwork we have to do some messing about
-if [[ "${ORIG_REALM}" =~ .(\.pub\.3gppnetwork\.org)$ ]] ; then
-    REALM=${ORIG_REALM}
-elif [[ "${ORIG_REALM}" =~ .(\.3gppnetwork\.org)$ ]] ; then
-    REALM=$(validate_3gppnetwork ${ORIG_REALM})
+if echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
+    REALM="${ORIG_REALM}"
+elif echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.3gppnetwork\.org)$' ; then
+    REALM=$(validate_3gppnetwork "${ORIG_REALM}")
 else
-    REALM=${ORIG_REALM}
+    REALM="${ORIG_REALM}"
 fi
 
 if [ -x "${DIGCMD}" ]; then

--- a/anp/configs/radsecproxy/naptr-openroaming.sh
+++ b/anp/configs/radsecproxy/naptr-openroaming.sh
@@ -17,7 +17,6 @@ test -n "${1}" || usage
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
-GREPCMD=$(command -v grep)
 
 validate_host() {
          echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
@@ -80,9 +79,9 @@ if [ -z "${ORIG_REALM}" ]; then
 fi
 
 # for 3gppnetwork we have to do some messing about
-if echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
+if echo "${ORIG_REALM}" |grep -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
     REALM="${ORIG_REALM}"
-elif echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.3gppnetwork\.org)$' ; then
+elif echo "${ORIG_REALM}" |grep -Eq '.(\.3gppnetwork\.org)$' ; then
     REALM=$(validate_3gppnetwork "${ORIG_REALM}")
 else
     REALM="${ORIG_REALM}"

--- a/hybrid/Dockerfile
+++ b/hybrid/Dockerfile
@@ -1,11 +1,11 @@
 #From https://github.com/bgernert/docker-radsecproxy/blob/master/Dockerfile
 # Use official Alpine release
-FROM alpine:3.14.3 as build
+FROM alpine:3.22.0 as build
 
 # Maintainer
 LABEL maintainer="Björn Gernert <mail@bjoern-gernert.de>"
 
-ENV RADSECVERSION 1.9.1
+ENV RADSECVERSION 1.11.2
 ENV RADSECURL https://github.com/radsecproxy/radsecproxy/releases/download/${RADSECVERSION}/
 ENV RADSECFILENAME radsecproxy-${RADSECVERSION}.tar.gz
 
@@ -36,7 +36,7 @@ RUN make && make install
 # --- --- ---
 
 # Create Radsecproxy container
-FROM alpine:3.14.3
+FROM alpine:3.22.0
 
 # Update apk
 RUN apk update

--- a/hybrid/Dockerfile
+++ b/hybrid/Dockerfile
@@ -42,7 +42,7 @@ FROM alpine:3.14.3
 RUN apk update
 
 # Install openssl, ca-certificates, nettle and tini
-RUN apk add --no-cache openssl ca-certificates bash nettle tini bind-tools
+RUN apk add --no-cache openssl ca-certificates bash nettle tini bind-tools grep
 
 # Copy from 'build' stage
 COPY --from=build /root/output/ /

--- a/hybrid/configs/radsecproxy/naptr-openroaming.sh
+++ b/hybrid/configs/radsecproxy/naptr-openroaming.sh
@@ -17,6 +17,7 @@ test -n "${1}" || usage
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
+GREPCMD=$(command -v grep)
 
 validate_host() {
          echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
@@ -79,12 +80,12 @@ if [ -z "${ORIG_REALM}" ]; then
 fi
 
 # for 3gppnetwork we have to do some messing about
-if [[ "${ORIG_REALM}" =~ .(\.pub\.3gppnetwork\.org)$ ]] ; then
-    REALM=${ORIG_REALM}
-elif [[ "${ORIG_REALM}" =~ .(\.3gppnetwork\.org)$ ]] ; then
-    REALM=$(validate_3gppnetwork ${ORIG_REALM})
+if echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
+    REALM="${ORIG_REALM}"
+elif echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.3gppnetwork\.org)$' ; then
+    REALM=$(validate_3gppnetwork "${ORIG_REALM}")
 else
-    REALM=${ORIG_REALM}
+    REALM="${ORIG_REALM}"
 fi
 
 if [ -x "${DIGCMD}" ]; then

--- a/hybrid/configs/radsecproxy/naptr-openroaming.sh
+++ b/hybrid/configs/radsecproxy/naptr-openroaming.sh
@@ -17,7 +17,6 @@ test -n "${1}" || usage
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
-GREPCMD=$(command -v grep)
 
 validate_host() {
          echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
@@ -80,9 +79,9 @@ if [ -z "${ORIG_REALM}" ]; then
 fi
 
 # for 3gppnetwork we have to do some messing about
-if echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
+if echo "${ORIG_REALM}" |grep -Eq '.(\.pub\.3gppnetwork\.org)$' ; then
     REALM="${ORIG_REALM}"
-elif echo "${ORIG_REALM}" |${GREPCMD} -Eq '.(\.3gppnetwork\.org)$' ; then
+elif echo "${ORIG_REALM}" |grep -Eq '.(\.3gppnetwork\.org)$' ; then
     REALM=$(validate_3gppnetwork "${ORIG_REALM}")
 else
     REALM="${ORIG_REALM}"


### PR DESCRIPTION
Fixing some broken things in my previous pull request. /bin/bash has some syntax that is not available in /bin/sh. Radsecproxy uses /bin/sh by default to launch scripts.